### PR TITLE
fix: Declaration add to be recnognized as ts lib.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "target": "es2019",
     "esModuleInterop": true,
+    "declaration": true,
     "sourceMap": true,
     "rootDirs": ["src", "tests"],
     "baseUrl": "src",


### PR DESCRIPTION
Adição da flag "declaration" no tsconfig.json.
Essa flag faz com que quando habilitada (true) o processo de build gere os arquivos  ***.d.ts** permitindo que o modulo seja interpretado como um modulo de typescript