### PR TITLE
#5 fix: correct function return types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import diacritics from './diacritics'
 
-function replaceSpecialCharacters (text: string): String {
+function replaceSpecialCharacters (text: string): string {
   const diacriticsMap = {}
   for (let i = 0; i < diacritics.length; i++) {
     const letters = diacritics[i].letters
@@ -9,7 +9,7 @@ function replaceSpecialCharacters (text: string): String {
     }
   }
 
-  function replace (refinedText: string): String {
+  function replace (refinedText: string): string {
     if (refinedText) {
       return refinedText.replace(/[^\u0000-\u007E]/g, function (a) {
         return diacriticsMap[a] || a


### PR DESCRIPTION
#5 Fix: I believe this is a bug resulting from the migration to typescript.  The return type of `String` is invalid as it is a wrapper object, not a type primitive.

I had a project using this package that breaks with error messaging around this type when we attempted to upgrade.  

I ran all unit tests with this change, and all are passing.