### PR TITLE
chore: request 2.0.1 documentation release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
   "release-type": "node",
   "packages": {
     ".": {
-      "package-name": "replace-special-characters"
+      "package-name": "replace-special-characters",
+      "release-as": "2.0.1"
     }
   }
 }


### PR DESCRIPTION
## Summary

- request version 2.0.1 from Release Please
- publish the refreshed README already merged into master

## Impact

Documentation-only release. No runtime behavior or public API changes.

## Validation

- npm test
- npm run check

## Follow-up

Remove the temporary `release-as` override after v2.0.1 is created.