### PR TITLE
fix: publish refreshed package documentation

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,7 @@
   "release-type": "node",
   "packages": {
     ".": {
-      "package-name": "replace-special-characters",
-      "release-as": "2.0.1"
+      "package-name": "replace-special-characters"
     }
   }
 }


### PR DESCRIPTION
## Summary

- remove the temporary `release-as` override
- record the npm package documentation update as a patch-level packaging fix
- allow Release Please to create the 2.0.1 release PR

## Impact

Documentation-only release. No runtime behavior or public API changes.

## Validation

- npm run check